### PR TITLE
switch to alaviss's fork of hlibgit2

### DIFF
--- a/gittyup.nimble
+++ b/gittyup.nimble
@@ -4,4 +4,4 @@ description = "higher-level libgit2 bindings"
 license = "MIT"
 
 requires "https://github.com/disruptek/badresults >= 2.0.0 & < 3.0.0"
-requires "https://github.com/haxscramper/hlibgit2 >= 0.1.5 & < 1.0.0"
+requires "https://github.com/alaviss/hlibgit2 >= 0.1.7 & < 1.0.0"


### PR DESCRIPTION
This fork contains a fix for memory corruption observed in nimph with nimskull.